### PR TITLE
Declare Kotlin version in Gradle build scripts

### DIFF
--- a/adapter/build.gradle.kts
+++ b/adapter/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   application
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.50"
 }
 
 application {

--- a/analyser/build.gradle.kts
+++ b/analyser/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   application
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.50"
 }
 
 application {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.50"
 }
 
 dependencies {


### PR DESCRIPTION
Happy [Gradle 4.3 release](https://github.com/gradle/gradle/releases/tag/v4.3.0) day!

The Gradle team had to make a minor breaking change to the Kotlin DSL, but never fear as this automated pull request should fix the incompatibility by explicitly declaring the Kotlin JVM version in your Kotlin build scripts. See https://github.com/gradle/kotlin-dsl/releases/tag/v0.12.0.

Have a pleasant day! ☀️